### PR TITLE
Remove MetricsCollector.plot()

### DIFF
--- a/pfsim/collector.py
+++ b/pfsim/collector.py
@@ -16,11 +16,6 @@ class MetricsCollector:
         for metric in self.metrics:
             metric.report()
 
-    def plot(self, output_dir):
-        for metric in self.metrics:
-            path = Path(output_dir) / Path(metric.name).with_suffix(".png")
-            metric.plot(str(path))
-
     def output_csv(self, output_dir):
         for metric in self.metrics:
             path = Path(output_dir) / Path(metric.name).with_suffix(".csv")


### PR DESCRIPTION
Since #21 deleted `Samples.plot()` and `TimeSeriesSamples.plot()`, we don't need this anymore.